### PR TITLE
replace deprecated include by import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
         - users_prune in [ True, False ]
         # OpenBSD 5.7 was the last version that came with sudo installed.
 
-- include: sudo.yml
+- import_tasks: sudo.yml
   when: users_use_sudo
 
 - name: Create groups
@@ -52,8 +52,8 @@
   notify:
       - Update SMTPd database
 
-- include: lock_root_ssh.yml
+- import_tasks: lock_root_ssh.yml
   when: users_lock_root_ssh
 
-- include: prune.yml
+- import_tasks: prune.yml
   when: users_prune


### PR DESCRIPTION
It is just a simple /s/include/import_tasks
Not a big deal but I just upgraded Ansible and I would prefer not disable deprecation warning in my config file.
Below the warning message:
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 
'include_tasks' for dynamic inclusions. This feature will be removed in a future release. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
